### PR TITLE
Fix LOG_ADDRESS_SERVER

### DIFF
--- a/ebot-cs2-install.sh
+++ b/ebot-cs2-install.sh
@@ -131,7 +131,7 @@ DELAY_BUSY_SERVER = 120
 NB_MAX_MATCHS = 0
 PAUSE_METHOD = "nextRound" ; nextRound or instantConfirm or instantNoConfirm
 NODE_STARTUP_METHOD = "node" ; binary file name or none in case you are starting it with forever or manually
-LOG_ADDRESS_SERVER = "'$PUBLIC_IP':12345" ; todo: check if this runs on localhost or external ip
+LOG_ADDRESS_SERVER = "http://'$PUBLIC_IP':12345" ; todo: check if this runs on localhost or external ip
 WEBSOCKET_SECRET_KEY = "'$websocket_secret'"
 
 [Redis]


### PR DESCRIPTION
This will fix issue, where if not set correctly, server console will spit out this constantly
`src/common/httpclient.cpp (808) : pHost && *pHost
Internal HTTP error posting to url log-server-ip:12345/game-server-ip:27035
Internal HTTP error posting to url log-server-ip:12345/game-server-ip:27035
Internal HTTP error posting to url log-server-ip:12345/game-server-ip:27035
Internal HTTP error posting to url log-server-ip:12345/game-server-ip:27035
Internal HTTP error posting to url log-server-ip:12345/game-server-ip:27035`