### PR TITLE
Added default_overtime_enable in app_user.yml

### DIFF
--- a/ebot-cs2-install.sh
+++ b/ebot-cs2-install.sh
@@ -191,6 +191,7 @@ echo '# ----------------------------------------------------------------------
 
   default_max_round: 12
   default_rules: esl5on5
+  default_overtime_enable: false
   default_overtime_max_round: 3
   default_overtime_startmoney: 12000
 


### PR DESCRIPTION
This change is w.r.t. this PR: https://github.com/deStrO/eBot-CSGO-Web/pull/111/files
A new flag has been added in app_user.yml for default_overtime_enable, so adding the same in the installation script